### PR TITLE
ValidPositiveAttribute.cs has been changed

### DIFF
--- a/src/Validation/Annotations/ValidPositiveAttribute.cs
+++ b/src/Validation/Annotations/ValidPositiveAttribute.cs
@@ -11,15 +11,10 @@ namespace Validation.Annotations
         {
             if (AllowDefaultValue && value == default)
                 return true;
-            
-            if (!(value is double s))
-            {
-                return false;
-            }
 
             try
             {
-                Guard.Positive(s, "Positive");
+                Guard.Positive(Convert.ToDecimal(value), "Positive");
                 return true;
             }
             catch

--- a/src/Validation/Annotations/ValidPositiveAttribute.cs
+++ b/src/Validation/Annotations/ValidPositiveAttribute.cs
@@ -5,8 +5,13 @@ namespace Validation.Annotations
 {
     public class ValidPositiveAttribute : ValidationAttribute
     {
+        public bool AllowDefaultValue { get; set; }
+
         public override bool IsValid(object value)
         {
+            if (AllowDefaultValue && value == default)
+                return true;
+            
             if (!(value is double s))
             {
                 return false;

--- a/src/Validation/Guard.cs
+++ b/src/Validation/Guard.cs
@@ -43,6 +43,14 @@ namespace System
             }
         }
 
+        public static void Positive(decimal source, string name)
+        {
+            if (source <= 0)
+            {
+                throw new ArgumentException($"{name} must be greater than 0");
+            }
+        }
+
         public static void ContainsElement<T>(this IEnumerable<T> source, string name)
         {
             if (source == null || !source.Any())


### PR DESCRIPTION
making ValidPositiveAttribute.cs to accept default values while declaring props like :

public int? OldOrderId { get; set;}